### PR TITLE
add loading spinner

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -11,10 +11,11 @@
     <div class="logo"></div>
 
     <ge-autocomplete
-      apiKey='ge-2550bcc43e8dd92e'
+      apiKey='ge-9ccf84885004f273'
       size='4'
       lang='en'
       boundary.country='de'
+      __host='api.dev.geocode.earth'
     ></ge-autocomplete>
     <pre id="result"></pre>
   </div>

--- a/src/autocomplete/autocomplete.css
+++ b/src/autocomplete/autocomplete.css
@@ -29,6 +29,8 @@
     rgba(0, 0, 0, 0) 0px 0px 0px 0px,
     rgba(0, 0, 0, 0.05) 0px 1px 2px 0px;
 
+  --loading-color: var(--gray-500);
+
   --results-bg: #fff;
   --results-z-index: 10;
   --results-shadow:
@@ -75,13 +77,22 @@
   display: block;
   width: 100%;
   border: 1px solid var(--input-border-color);
-  padding: 13px 12px;
+  padding: 13px 55px 13px 12px; /* 12 + 31 + 12 = 55, loading spinner is 31 wide */;
   border-radius: var(--border-radius);
   appearance: none;
   -webkit-appearance: none;
   -moz-ppearance: none;
   outline: none;
   box-shadow: var(--input-shadow);
+}
+
+.loading {
+  position: absolute;
+  right: 12px;
+  top: 7px;
+  width: 31px;
+  height: 31px;
+  stroke: var(--loading-color);
 }
 
 .results {

--- a/src/icons.js
+++ b/src/icons.js
@@ -12,3 +12,48 @@ export const LocationMarker = ({className}) =>
     <path fillRule="evenodd" d="M5.05 4.05a7 7 0 119.9 9.9L10 18.9l-4.95-4.95a7 7 0 010-9.9zM10 11a2 2 0 100-4 2 2 0 000 4z" clipRule="evenodd" />
   </svg>
 
+/**
+ * SVG Loaders (github.com/SamHerbert/SVG-Loaders)
+ * Copyright (c) 2014 Sam Herbert
+ *
+ * @license MIT
+ */
+
+// this is the `puff` loader
+export const Loading = ({ className }) =>
+  <svg width="44" height="44" viewBox="0 0 44 44" xmlns="http://www.w3.org/2000/svg" stroke="currentColor" className={className}>
+    <g fill="none" fillRule="evenodd" strokeWidth="2">
+      <circle cx="22" cy="22" r="1">
+        <animate attributeName="r"
+          begin="0s" dur="1.4s"
+          values="1; 20"
+          calcMode="spline"
+          keyTimes="0; 1"
+          keySplines="0.165, 0.84, 0.44, 1"
+          repeatCount="indefinite" />
+        <animate attributeName="stroke-opacity"
+          begin="0s" dur="1.4s"
+          values="1; 0"
+          calcMode="spline"
+          keyTimes="0; 1"
+          keySplines="0.3, 0.61, 0.355, 1"
+          repeatCount="indefinite" />
+      </circle>
+      <circle cx="22" cy="22" r="1">
+        <animate attributeName="r"
+          begin="-0.7s" dur="1.4s"
+          values="1; 20"
+          calcMode="spline"
+          keyTimes="0; 1"
+          keySplines="0.165, 0.84, 0.44, 1"
+          repeatCount="indefinite" />
+        <animate attributeName="stroke-opacity"
+          begin="-0.7s" dur="1.4s"
+          values="1; 0"
+          calcMode="spline"
+          keyTimes="0; 1"
+          keySplines="0.3, 0.61, 0.355, 1"
+          repeatCount="indefinite" />
+      </circle>
+    </g>
+  </svg>


### PR DESCRIPTION
The spinner is shown as the user types (and requests are being made) and is hidden when a request comes back with results, as well as when an error occurs.

The spinner is an animated SVG from here (2nd row on the right): https://samherbert.net/svg-loaders/
I adjusted the animation duration to make it a bit faster. We can chose a different one of course, but I’d like it to be an animated SVG because they’re quite small and we can easily bundle them (as is shown in this PR).


https://user-images.githubusercontent.com/1345545/117289661-25932280-ae6d-11eb-8ae5-4589a492a5ea.mov

