### PR TITLE
programatically trigger searches by setting `value` attribute

### DIFF
--- a/src/autocomplete/autocomplete.js
+++ b/src/autocomplete/autocomplete.js
@@ -28,13 +28,18 @@ export default ({
   const [isLoading, setIsLoading] = useState(false)
   const inputRef = useRef()
 
+  // setting params & options as state so they can be passed to useMemo as dependencies,
+  // which doesn’t work if they’re just objects as the internal comparison fails
+  const [apiParams, setApiParams] = useState(params)
+  const [apiOptions, setApiOptions] = useState(options)
+
   // Geocode Earth Autocomplete Client
   const autocomplete = useMemo(() => {
     return createAutocomplete(apiKey, params, {
       ...options,
       client: `ge-autocomplete${typeof VERSION !== 'undefined' ? `-${VERSION}` : ''}`
     })
-  }, [apiKey, params, options])
+  }, [apiKey, apiParams, apiOptions])
 
   // search queries the autocomplete API
   const search = useCallback(text => {

--- a/src/index.js
+++ b/src/index.js
@@ -57,6 +57,7 @@ class GEAutocomplete extends HTMLElement {
       'debounce',
       'lang',
       'size',
+      'value',
       'layers',
       'sources',
       'boundary.country',
@@ -73,6 +74,16 @@ class GEAutocomplete extends HTMLElement {
     ]
   }
 
+  // getter & setter for the value attribute as _if_ any attribute is programatically
+  // changed then it’s this one
+  get value () {
+    return this.getAttribute('value')?.trim()
+  }
+
+  set value (text) {
+    this.setAttribute('value', text)
+  }
+
   // props returns element attributes converted to props to be passed on
   // to the react component
   get props () {
@@ -81,6 +92,7 @@ class GEAutocomplete extends HTMLElement {
       placeholder: this.getAttribute('placeholder'),
       autoFocus: this.getAttribute('autofocus') !== null,
       debounce: parseInt(this.getAttribute('debounce')),
+      value: this.value,
       params: compact({
         lang: this.getAttribute('lang'),
         size: parseInt(this.getAttribute('size')),


### PR DESCRIPTION
This PR introduces the ability to set the `value` attribute on the custom element to trigger a search with that value. The attribute can be set using the native `setAttribute` API, but getters and setters are also available for an even cleaner api.

In addition to being able to set the `value` attribute programmatically it can also be set initially, which will trigger the search as soon as the element is initialized.