### PR TITLE
set line-height on INPUT element

### DIFF
--- a/src/autocomplete/autocomplete.css
+++ b/src/autocomplete/autocomplete.css
@@ -72,6 +72,7 @@
 .input {
   font-size: 16px;
   font-family: var(--font-family);
+  line-height: 20px;
   color: var(--input-color);
   background: var(--input-bg);
   display: block;


### PR DESCRIPTION
This PR sets the `line-height` of the `<INPUT>` element to `20px` which makes the vertical spacing of the input match the vertical spacing of the result items:

<img width="721" alt="Screenshot 2021-06-22 at 14 11 22" src="https://user-images.githubusercontent.com/738069/122922300-93f95900-d3b7-11eb-8e57-d84c0dfb2cd1.png">

<img width="721" alt="Screenshot 2021-06-22 at 14 11 06" src="https://user-images.githubusercontent.com/738069/122922295-922f9580-d3b7-11eb-91d7-9e8fd3955db2.png">

It's fairly subtle I admit (4px difference) 😆 