### PR TITLE
Search Icon

### DIFF
--- a/src/autocomplete/autocomplete.css
+++ b/src/autocomplete/autocomplete.css
@@ -29,6 +29,7 @@
     rgba(0, 0, 0, 0) 0px 0px 0px 0px,
     rgba(0, 0, 0, 0.05) 0px 1px 2px 0px;
 
+  --search-icon-color: var(--gray-500);
   --loading-color: var(--gray-500);
 
   --results-bg: #fff;
@@ -78,13 +79,23 @@
   display: block;
   width: 100%;
   border: 1px solid var(--input-border-color);
-  padding: 13px 55px 13px 12px; /* 12 + 31 + 12 = 55, loading spinner is 31 wide */;
+  padding: 13px 55px 13px 41px; /* 12 + 31 + 12 = 55, loading spinner is 31 wide */;
   border-radius: var(--border-radius);
   appearance: none;
   -webkit-appearance: none;
   -moz-ppearance: none;
   outline: none;
   box-shadow: var(--input-shadow);
+}
+
+.search-icon {
+  position: absolute;
+  color: var(--search-icon-color);
+  margin-right: 10px;
+  left: 12px;
+  top: 13px;
+  width: 20px;
+  height: 20px;
 }
 
 .loading {

--- a/src/autocomplete/autocomplete.css
+++ b/src/autocomplete/autocomplete.css
@@ -72,6 +72,7 @@
 .input {
   font-size: 16px;
   font-family: var(--font-family);
+  line-height: 20px;
   color: var(--input-color);
   background: var(--input-bg);
   display: block;

--- a/src/autocomplete/autocomplete.js
+++ b/src/autocomplete/autocomplete.js
@@ -4,7 +4,7 @@ import { createAutocomplete } from '@geocodeearth/core-js'
 import debounce from 'lodash.debounce'
 import css from './autocomplete.css'
 import strings from '../strings'
-import { LocationMarker, Loading } from '../icons'
+import { LocationMarker, Loading, SearchIcon } from '../icons'
 
 const emptyResults = {
   text: '',
@@ -144,6 +144,7 @@ export default ({
       <label {...getLabelProps()} className='label'>{placeholder}</label>
 
       <div {...getComboboxProps()} >
+        <SearchIcon className='search-icon' />
         <input {...getInputProps({ref: inputRef})} spellCheck={false} placeholder={placeholder} className='input' />
         {isLoading && <Loading className={'loading'} />}
       </div>

--- a/src/icons.js
+++ b/src/icons.js
@@ -12,6 +12,18 @@ export const LocationMarker = ({className}) =>
     <path fillRule="evenodd" d="M5.05 4.05a7 7 0 119.9 9.9L10 18.9l-4.95-4.95a7 7 0 010-9.9zM10 11a2 2 0 100-4 2 2 0 000 4z" clipRule="evenodd" />
   </svg>
 
+
+/**
+ * Heroicons v1.0.0 (heroicons.com)
+ * Copyright (c) 2020 Refactoring UI Inc.
+ *
+ * @license MIT
+ */
+export const SearchIcon = ({className}) =>
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" stroke="currentColor" fill="none" className={className}>
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+  </svg>
+
 /**
  * SVG Loaders (github.com/SamHerbert/SVG-Loaders)
  * Copyright (c) 2014 Sam Herbert


### PR DESCRIPTION
This DRAFT PR is open for discussion, it may not be everyone's 'cup-o-tea' 🤷 
note: this is branched off https://github.com/geocodeearth/autocomplete-element/pull/12

<img width="727" alt="Screenshot 2021-06-22 at 14 37 16" src="https://user-images.githubusercontent.com/738069/122926115-a8d7eb80-d3bb-11eb-9a8b-48bbaa7aa3e5.png">

The motivation for this PR was that I felt the horizontal alignment of the search text and results text should match, what do you think?

![Screenshot 2021-06-22 at 14 41 31](https://user-images.githubusercontent.com/738069/122926411-f05e7780-d3bb-11eb-9520-cf01b712820d.png)

This is my first PR to this repo so the code might need some cleanup before we consider merging this, things like variables, class naming etc.