### PR TITLE
customization: CSS, String template, Row template

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Similar to the string template mentioned above, you can use the row template to 
 <ge-autocomplete api_key="…">
   <template row>
     <div class="custom-row ${feature.active ? 'custom-row--active' : null}">
-      <img src="/flags/${feature.properties.country_a.png" alt="${feature.country_a}">
+      <img src="/flags/${feature.properties.country_a.png}" alt="${feature.properties.country_a}">
       <span>${feature.properties.label}</span>
     </div>
   </template>

--- a/README.md
+++ b/README.md
@@ -114,6 +114,77 @@ The element also emits **events** as a user interacts with it. This is how you c
 |`change`       |`string`      |Dispatched with every keystroke as the user types (not debounced).|
 |`error`        |`Error`       |Dispatched if an error occures during the request (for example if the rate limit was exceeded.)|
 
+
+
+## Customization
+
+We did our best to design the element in such a way that it can be used as is in a lot of different contexts without needing to adjust how it looks. However, there certainly can be situations where customization is necessary. The element supports three different customization APIs:
+
+1. Custom CSS (variables)
+2. A string template as well as
+3. A row template
+
+### 1. Custom CSS
+
+We use CSS variables for almost all properties that you would want to customize. This includes the font family, background or shadow of the input and the hover state for a result just to name a few. For a list of all available variables please check the source CSS file directly ([`/src/autocomplete/autocomplete.css`](src/autocomplete/autocomplete.css)).
+
+You can adjust these variables by placing a `<style>` tag _inside_ the element, like so:
+
+```html
+<ge-autocomplete api_key="…">
+  <style>
+     :host {
+       --input-bg: salmon;
+       --input-color: green;
+       --loading-color: hotpink;
+    }
+  </style>
+</ge-autocomplete>
+```
+
+**Important:** While it is technically possible to override the actual classnames the element uses internally, we do not consider those part of the public API. That means they can change without a new major version, which could break your customization. The CSS variables on the other hand are specifically meant to be customized, which is why they will stay consistent even if the internal markup changes.
+
+If you would like to customize a property for which there is no variable we’d be happy to accept a pull-request or issue about it.
+
+### 2. String Template
+
+If you want to customize how a feature is turned into a string for rendering (in the results as well as the input field after it was selected), you can define a custom string template. This allows you to use the [lodash template language][_template] to access every property of the feature to build a custom string.
+
+```html
+<ge-autocomplete api_key="…">
+  <template string>
+    ${feature.properties.name} (${feature.properties.id}, ${feature.properties.source})
+  </template>
+</ge-autocomplete>
+```
+
+**Important:** Make sure to return a plain string here, no HTML. The reason for this is that this template will also be used in the input field itself after a result has been selected, which doesn’t support HTML.
+
+### 3. Row Template
+
+Similar to the string template mentioned above, you can use the row template to define how a single row in the results is rendered. The key here is that this supports full HTML:
+
+```html
+<ge-autocomplete api_key="…">
+  <template row>
+    <div class="custom-row ${feature.active ? 'custom-row--active' : null}">
+      <img src="/flags/${feature.properties.country_a.png" alt="${feature.country_a}">
+      <span>${feature.properties.label}</span>
+    </div>
+  </template>
+</ge-autocomplete>
+```
+
+**Pro Tip™:** Use the `active` property to check if the current row is being hovered over or activated via arrow keys.
+
+The example above could render a little flag icon for the result’s country, for example. You can customize the styling by defining custom classes in the same way you would customize the CSS variables. It’s best to prefix your classes to avoid conflicts with internal classnames of the element.
+
+The [lodash template language][_template] supports much more than just straight variables. Please refer to their docs directly to understand how it works. It’s pretty powerful.
+
+  [_template]: https://lodash.com/docs/4.17.15#template
+
+
+
 ## Example
 
 Please see the `example` folder. You can follow the steps in the [**Development**](#development) section to run them directly, too.

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ If you want to customize how a feature is turned into a string for rendering (in
 ```html
 <ge-autocomplete api_key="…">
   <template string>
-    ${feature.properties.name} (${feature.properties.id}, ${feature.properties.source})
+    ${item.feature.properties.name} (${item.feature.properties.id}, ${item.feature.properties.source})
   </template>
 </ge-autocomplete>
 ```
@@ -167,15 +167,15 @@ Similar to the string template mentioned above, you can use the row template to 
 ```html
 <ge-autocomplete api_key="…">
   <template row>
-    <div class="custom-row ${feature.active ? 'custom-row--active' : null}">
-      <img src="/flags/${feature.properties.country_a.png}" alt="${feature.properties.country_a}">
-      <span>${feature.properties.label}</span>
+    <div class="custom-row ${item.active ? 'custom-row--active' : null}">
+      <img src="/flags/${item.feature.properties.country_a.png}" alt="${item.feature.properties.country_a}">
+      <span>${item.feature.properties.label}</span>
     </div>
   </template>
 </ge-autocomplete>
 ```
 
-**Pro Tip™:** Use the `active` property to check if the current row is being hovered over or activated via arrow keys.
+**Pro Tip™:** Use the `item.active` property to check if the current row is being hovered over or activated via arrow keys.
 
 The example above could render a little flag icon for the result’s country, for example. You can customize the styling by defining custom classes in the same way you would customize the CSS variables. It’s best to prefix your classes to avoid conflicts with internal classnames of the element.
 

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Similar to the string template mentioned above, you can use the row template to 
 </ge-autocomplete>
 ```
 
-**Pro Tip™:** Use the `item.active` property to check if the current row is being hovered over or activated via arrow keys.
+**Pro Tip™:** Use the `item.active` property to check if the current row is being hovered over or activated via arrow keys. See below for additional properties.
 
 The example above could render a little flag icon for the result’s country, for example. You can customize the styling by defining custom classes in the same way you would customize the CSS variables. It’s best to prefix your classes to avoid conflicts with internal classnames of the element.
 
@@ -184,6 +184,18 @@ The [lodash template language][_template] supports much more than just straight 
   [_template]: https://lodash.com/docs/4.17.15#template
 
 
+### Additional Template Properties
+
+Inside a template you can access the following properties:
+
+|Property|Type|Contains|
+|--------|----|--------|
+|`item.feature`|Object|The selected item, a [GeoJSON Feature][geojsonfeature]|
+|`item.active`|Boolean|Whether or not the current item is active (hovered or selected with arrow keys)|
+|`item.searchTerm`|String|The current value of the search input field|
+|`item.index`|Number|The index of the item in the result list|
+
+  [geojsonfeature]: https://github.com/geocodeearth/core-js/blob/main/src/geojson.ts
 
 ## Example
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,9 @@
         "@geocodeearth/core-js": "^0.0.7",
         "downshift": "6.1.3",
         "lodash.debounce": "^4.0.8",
+        "lodash.escape": "^4.0.1",
+        "lodash.template": "^4.5.0",
+        "lodash.unescape": "^4.0.1",
         "react": "^17.0.2",
         "react-dom": "^17.0.2"
       },
@@ -103,9 +106,41 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/lodash._reinterpolate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+      "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
+    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "license": "MIT"
+    },
+    "node_modules/lodash.escape": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
+      "integrity": "sha1-yQRGkMIeBClL6qUXcS/e0fqI3pg="
+    },
+    "node_modules/lodash.template": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",
+      "integrity": "sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==",
+      "dependencies": {
+        "lodash._reinterpolate": "^3.0.0",
+        "lodash.templatesettings": "^4.0.0"
+      }
+    },
+    "node_modules/lodash.templatesettings": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
+      "integrity": "sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==",
+      "dependencies": {
+        "lodash._reinterpolate": "^3.0.0"
+      }
+    },
+    "node_modules/lodash.unescape": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
+      "integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw="
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -246,8 +281,40 @@
         "universalify": "^2.0.0"
       }
     },
+    "lodash._reinterpolate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+      "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
+    },
     "lodash.debounce": {
       "version": "4.0.8"
+    },
+    "lodash.escape": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
+      "integrity": "sha1-yQRGkMIeBClL6qUXcS/e0fqI3pg="
+    },
+    "lodash.template": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",
+      "integrity": "sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==",
+      "requires": {
+        "lodash._reinterpolate": "^3.0.0",
+        "lodash.templatesettings": "^4.0.0"
+      }
+    },
+    "lodash.templatesettings": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
+      "integrity": "sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==",
+      "requires": {
+        "lodash._reinterpolate": "^3.0.0"
+      }
+    },
+    "lodash.unescape": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
+      "integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw="
     },
     "loose-envify": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "@geocodeearth/core-js": "^0.0.7",
     "downshift": "6.1.3",
     "lodash.debounce": "^4.0.8",
+    "lodash.escape": "^4.0.1",
+    "lodash.template": "^4.5.0",
+    "lodash.unescape": "^4.0.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },

--- a/src/autocomplete/autocomplete.js
+++ b/src/autocomplete/autocomplete.js
@@ -5,6 +5,7 @@ import debounce from 'lodash.debounce'
 import css from './autocomplete.css'
 import strings from '../strings'
 import { LocationMarker, Loading } from '../icons'
+import escape from '../escape'
 
 const emptyResults = {
   text: '',
@@ -22,7 +23,8 @@ export default ({
   onSelect: userOnSelectItem,
   onChange: userOnChange,
   onError: userOnError,
-  environment = window
+  environment = window,
+  rowTemplate
 }) => {
   const [results, setResults] = useState(emptyResults)
   const [isLoading, setIsLoading] = useState(false)
@@ -150,20 +152,33 @@ export default ({
 
       <ol {...getMenuProps()} className={showResults ? 'results' : 'results-empty'}>
         {showResults &&
-          results.features.map((item, index) => (
-            <li
-              className={
-                highlightedIndex === index
-                  ? 'result-item result-item-active'
-                  : 'result-item'
-              }
-              key={item.properties.id}
-              {...getItemProps({ item, index })}
-            >
-              <LocationMarker className='result-item-icon' />
-              {itemToString(item)}
-            </li>
-          ))}
+          results.features.map((item, index) => {
+            // render row with custom template, if available
+            // the feature itself is recursively escaped as we can’t guarantee safe data from the API
+            if (typeof rowTemplate === 'function') {
+              return <li
+                key={item.properties.id}
+                {...getItemProps({ item, index })}
+                dangerouslySetInnerHTML={{ __html: rowTemplate(escape({
+                  ...item,
+                  active: highlightedIndex === index
+                })) }}
+              />
+            } else {
+              return <li
+                className={
+                  highlightedIndex === index
+                    ? 'result-item result-item-active'
+                    : 'result-item'
+                }
+                key={item.properties.id}
+                {...getItemProps({ item, index })}
+              >
+                <LocationMarker className='result-item-icon' />
+                {itemToString(item)}
+              </li>
+            }
+          })}
 
         <div className='attribution'>
           ©&nbsp;<a href="https://geocode.earth">Geocode Earth</a>,&nbsp;

--- a/src/autocomplete/autocomplete.js
+++ b/src/autocomplete/autocomplete.js
@@ -24,7 +24,8 @@ export default ({
   onChange: userOnChange,
   onError: userOnError,
   environment = window,
-  rowTemplate
+  rowTemplate,
+  stringTemplate
 }) => {
   const [results, setResults] = useState(emptyResults)
   const [isLoading, setIsLoading] = useState(false)
@@ -106,7 +107,13 @@ export default ({
   }
 
   // turns an autocomplete result (feature) into a string
-  const itemToString = ({ properties: { label } }) => label
+  const itemToString = (feature) => {
+    if (typeof stringTemplate === 'function') {
+      return stringTemplate(escape(feature))
+    }
+
+    return feature.properties.label
+  }
 
   // focus the input field if requested
   useEffect(() => {

--- a/src/autocomplete/autocomplete.js
+++ b/src/autocomplete/autocomplete.js
@@ -107,9 +107,9 @@ export default ({
   }
 
   // turns an autocomplete result (feature) into a string
-  const itemToString = (feature) => {
+  const itemToString = (feature, extra) => {
     if (typeof stringTemplate === 'function') {
-      return stringTemplate(escape(feature))
+      return stringTemplate({feature, ...extra})
     }
 
     return feature.properties.label
@@ -166,12 +166,15 @@ export default ({
               return <li
                 key={item.properties.id}
                 {...getItemProps({ item, index })}
-                dangerouslySetInnerHTML={{ __html: rowTemplate(escape({
-                  ...item,
-                  active: highlightedIndex === index
-                })) }}
-              />
-            } else {
+                dangerouslySetInnerHTML={{
+                  __html: rowTemplate({
+                    feature: escape(item),
+                    active: highlightedIndex === index,
+                    searchTerm: inputRef.current.value,
+                    index
+                  })}}
+                  />
+                } else {
               return <li
                 className={
                   highlightedIndex === index
@@ -182,7 +185,11 @@ export default ({
                 {...getItemProps({ item, index })}
               >
                 <LocationMarker className='result-item-icon' />
-                {itemToString(item)}
+                {itemToString(item, {
+                  active: highlightedIndex === index,
+                  searchTerm: inputRef.current.value,
+                  index
+                })}
               </li>
             }
           })}

--- a/src/escape.js
+++ b/src/escape.js
@@ -1,0 +1,18 @@
+import _escape from 'lodash.escape'
+
+// escape takes any value (primarily objects) and recursively escapes the values
+const escape = (v) => {
+  if (typeof v === 'string') return _escape(v)
+  if (typeof v === 'number' || typeof v === 'boolean') return v
+  if (Array.isArray(v)) return v.map(l => escape(l))
+
+  return Object.keys(v).reduce(
+    (attrs, key) => ({
+      ...attrs,
+      [key]: escape(v[key]),
+    }),
+    {}
+  )
+}
+
+export default escape

--- a/src/index.js
+++ b/src/index.js
@@ -133,7 +133,7 @@ class GEAutocomplete extends HTMLElement {
 
   connectedCallback () {
     this.importStyles()
-    this.importRowTemplate()
+    this.importTemplates()
     this.render()
   }
 
@@ -149,21 +149,28 @@ class GEAutocomplete extends HTMLElement {
     this.shadowRoot.appendChild(styles)
   }
 
-  // importRowTemplate looks for a <template row> tag inside the custom element
-  // and stores its contents as a lodash template, which is then passed on to
-  // the autocomplete component
-  importRowTemplate() {
-    const tmpl = this.querySelector('template[row]')
-    if (tmpl === null) return
+  // importTemplates looks for custom <template> tags inside this custom element,
+  // parses their content as a lodash template and stores them to be passed on
+  // to the autocomplete component
+  importTemplates() {
+    const templates = {
+      stringTemplate: this.querySelector('template[string]'),
+      rowTemplate: this.querySelector('template[row]')
+    }
 
-    this.rowTemplate = _template(
-      _unescape(tmpl.innerHTML.trim()), // unescape is important for `<%` etc. lodash tags
-      { variable: 'feature' } // namespace the passed in Feature as `feature` so missing keys don’t throw
-    )
+    Object.keys(templates).forEach(k => {
+      const tmpl = templates[k]
+      if (tmpl === null) return
 
-    // contrary to the way custom styles are handled above we remove the <template> when we’re done
-    // so it doesn’t hang around in the host document (not the Shadow DOM)
-    tmpl.remove()
+      this[k] = _template(
+        _unescape(tmpl.innerHTML.trim()), // unescape is important for `<%` etc. lodash tags
+        { variable: 'feature' } // namespace the passed in Feature as `feature` so missing keys don’t throw
+      )
+
+      // contrary to the way custom styles are handled above we remove the <template> when we’re done
+      // so it doesn’t hang around in the host document (not the Shadow DOM)
+      tmpl.remove()
+    })
   }
 
   render () {
@@ -171,7 +178,9 @@ class GEAutocomplete extends HTMLElement {
       <WebComponent
         {...this.props}
         host={this}
-        rowTemplate={this.rowTemplate} />,
+        stringTemplate={this.stringTemplate}
+        rowTemplate={this.rowTemplate}
+      />,
       this.shadowRoot
     )
   }

--- a/src/index.js
+++ b/src/index.js
@@ -130,7 +130,20 @@ class GEAutocomplete extends HTMLElement {
   }
 
   connectedCallback () {
+    this.importStyles()
     this.render()
+  }
+
+  // importStyles looks for a specific template tag inside the custom element
+  // and moves its content (expected to be a <style> tag) inside the Shadow DOM,
+  // which can be used to customize the styling of the component.
+  importStyles() {
+    const styles = this.querySelector('style')
+    if (styles === null) return
+
+    // appending the node somewhere else _moves_ automatically it so we don’t have
+    // to explicitly remove it
+    this.shadowRoot.appendChild(styles)
   }
 
   render () {

--- a/src/index.js
+++ b/src/index.js
@@ -164,7 +164,7 @@ class GEAutocomplete extends HTMLElement {
 
       this[k] = _template(
         _unescape(tmpl.innerHTML.trim()), // unescape is important for `<%` etc. lodash tags
-        { variable: 'feature' } // namespace the passed in Feature as `feature` so missing keys don’t throw
+        { variable: 'item' } // namespace the passed in item so missing keys don’t throw
       )
 
       // contrary to the way custom styles are handled above we remove the <template> when we’re done


### PR DESCRIPTION
This PR adds three different (but combinable) ways of customizing the visual style of the element:

1. custom css (variables)
2. string template
3. row template

As to not repeat everything in this PR description it’s best to read the documentation I wrote: https://github.com/geocodeearth/autocomplete-element/tree/feat/customization-templates#customization