### PR TITLE
custom debounce function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@geocodeearth/core-js": "^0.0.7",
         "downshift": "6.1.3",
-        "lodash.debounce": "^4.0.8",
         "lodash.escape": "^4.0.1",
         "lodash.template": "^4.5.0",
         "lodash.unescape": "^4.0.1",
@@ -110,10 +109,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
-    },
-    "node_modules/lodash.debounce": {
-      "version": "4.0.8",
-      "license": "MIT"
     },
     "node_modules/lodash.escape": {
       "version": "4.0.1",
@@ -285,9 +280,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
-    },
-    "lodash.debounce": {
-      "version": "4.0.8"
     },
     "lodash.escape": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   "dependencies": {
     "@geocodeearth/core-js": "^0.0.7",
     "downshift": "6.1.3",
-    "lodash.debounce": "^4.0.8",
     "lodash.escape": "^4.0.1",
     "lodash.template": "^4.5.0",
     "lodash.unescape": "^4.0.1",

--- a/src/autocomplete/autocomplete.js
+++ b/src/autocomplete/autocomplete.js
@@ -1,7 +1,7 @@
 import React, { useState, useMemo, useCallback, useRef, useEffect } from 'react'
 import { useCombobox } from 'downshift'
 import { createAutocomplete } from '@geocodeearth/core-js'
-import debounce from 'lodash.debounce'
+import debounce from '../debounce'
 import css from './autocomplete.css'
 import strings from '../strings'
 import { LocationMarker, Loading, Search as SearchIcon } from '../icons'
@@ -60,7 +60,7 @@ export default ({
   }, [autocomplete])
 
   const debouncedSearch = useCallback(
-    debounce(search, debounceWait, { trailing: true }),
+    debounce(search, debounceWait),
     [search]
    )
 

--- a/src/debounce.js
+++ b/src/debounce.js
@@ -1,0 +1,37 @@
+/**
+  debounce ensures that only one execution of $func
+  can occur within each $wait 'window'.
+
+  in the case where multiple executions have occured
+  within a single window, the most recent is used.
+
+  this differs from lodash.debouce in that we don't wait
+  for the events to stop coming in before calling $func.
+**/
+const debounce = (func, wait) => {
+  const schedule = {}
+
+  return function() {
+    const now = Date.now()
+
+    // a timestamp representing the leading edge of the current window
+    const window = Math.floor(Math.floor(now/wait)*wait)
+
+    // cancel any existing scheduled invocations for this window
+    if (window in schedule) {
+      clearTimeout(schedule[window])
+    }
+
+    // duration between now and the trailing edge of the window
+    // note: a delay of <= 0 causes $func to execute immediately
+    const delay = (window + wait) - now
+
+    // schedule invocation on the trailing edge of the window
+    schedule[window] = setTimeout(() => {
+      func.apply(null, arguments)
+      delete schedule[window]
+    }, delay)
+  }
+}
+
+export default debounce


### PR DESCRIPTION
after much discussion I've come to the conclusion that it's the lodash implementation of `_.debounce` that is causing the UI to not refresh as often as I'd like.

there's a [really amazing article](https://css-tricks.com/debouncing-throttling-explained-examples/) which covers debouce and throttle and has [a really cool demo](https://codepen.io/dcorb/pen/KVxGqN).

if you wiggle the mouse over the "Trigger Area" in that demo for several seconds you'll see that the function only triggers once you stop wiggling, it doesn't execute once per $delay, which I what I'd like to see for autocomplete search.

this PR includes a custom `debounce` function, it actually turned out very lean, the idea here is that we have "invocation windows" and we schedule execution at the trailing end of each window.

if another invocation occurs within the same window it replaces the previous one.