### PR TITLE
use throttle instead of debounce

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,11 @@ All configuration happens through **attributes** on the element. `api_key` is th
 
 Your Geocode Earth API key. [Sign up for a free trial »](https://geocode.earth)
 
-### `debounce`
+### `throttle`
 > defaults to `300`
 
 Used to prevent firing a request for every keystroke as the user types, in milliseconds.
+This is passed directly to the [`_.throttle`](https://lodash.com/docs/4.17.15#throttle) function.
 
 ### `size`
 > defaults to `10`

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,9 @@
       "dependencies": {
         "@geocodeearth/core-js": "^0.0.7",
         "downshift": "6.1.3",
-        "lodash.debounce": "^4.0.8",
         "lodash.escape": "^4.0.1",
         "lodash.template": "^4.5.0",
+        "lodash.throttle": "^4.1.1",
         "lodash.unescape": "^4.0.1",
         "react": "^17.0.2",
         "react-dom": "^17.0.2"
@@ -111,10 +111,6 @@
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
     },
-    "node_modules/lodash.debounce": {
-      "version": "4.0.8",
-      "license": "MIT"
-    },
     "node_modules/lodash.escape": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
@@ -136,6 +132,11 @@
       "dependencies": {
         "lodash._reinterpolate": "^3.0.0"
       }
+    },
+    "node_modules/lodash.throttle": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+      "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ="
     },
     "node_modules/lodash.unescape": {
       "version": "4.0.1",
@@ -286,9 +287,6 @@
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
     },
-    "lodash.debounce": {
-      "version": "4.0.8"
-    },
     "lodash.escape": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
@@ -310,6 +308,11 @@
       "requires": {
         "lodash._reinterpolate": "^3.0.0"
       }
+    },
+    "lodash.throttle": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+      "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ="
     },
     "lodash.unescape": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
   "dependencies": {
     "@geocodeearth/core-js": "^0.0.7",
     "downshift": "6.1.3",
-    "lodash.debounce": "^4.0.8",
     "lodash.escape": "^4.0.1",
     "lodash.template": "^4.5.0",
+    "lodash.throttle": "^4.1.1",
     "lodash.unescape": "^4.0.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"

--- a/src/autocomplete/autocomplete.js
+++ b/src/autocomplete/autocomplete.js
@@ -1,7 +1,7 @@
 import React, { useState, useMemo, useCallback, useRef, useEffect } from 'react'
 import { useCombobox } from 'downshift'
 import { createAutocomplete } from '@geocodeearth/core-js'
-import debounce from 'lodash.debounce'
+import throttle from 'lodash.throttle'
 import css from './autocomplete.css'
 import strings from '../strings'
 import { LocationMarker, Loading, Search as SearchIcon } from '../icons'
@@ -19,7 +19,7 @@ export default ({
   placeholder = strings.inputPlaceholder,
   value = '',
   autoFocus = false,
-  debounce: debounceWait = 200,
+  throttle: throttleWait = 200,
   onSelect: userOnSelectItem,
   onChange: userOnChange,
   onError: userOnError,
@@ -59,8 +59,8 @@ export default ({
     .catch(onError)
   }, [autocomplete])
 
-  const debouncedSearch = useCallback(
-    debounce(search, debounceWait, { trailing: true }),
+  const throttledSearch = useCallback(
+    throttle(search, throttleWait, { leading: true, trailing: true }),
     [search]
    )
 
@@ -88,7 +88,7 @@ export default ({
 
     if (searchOn.includes(type)) {
       setIsLoading(true)
-      debouncedSearch(term)
+      throttledSearch(term)
     }
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -56,7 +56,7 @@ class GEAutocomplete extends HTMLElement {
       'api_key',
       'placeholder',
       'autofocus',
-      'debounce',
+      'throttle',
       'lang',
       'size',
       'value',
@@ -93,7 +93,7 @@ class GEAutocomplete extends HTMLElement {
       apiKey: this.getAttribute('api_key')?.trim(),
       placeholder: this.getAttribute('placeholder'),
       autoFocus: this.getAttribute('autofocus') !== null,
-      debounce: parseInt(this.getAttribute('debounce')),
+      throttle: parseInt(this.getAttribute('throttle')),
       value: this.value,
       params: compact({
         lang: this.getAttribute('lang'),


### PR DESCRIPTION
this PR is a replacement for https://github.com/geocodeearth/autocomplete-element/pull/16 which is preferable since it's using a well tested implementation.

It replaces `_.debounce` with `_.throttle` and updates the API. This is a **breaking change**.