### PR TITLE
docs: document layers param, remove sources param documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,10 +69,10 @@ Sets whether the input should be automatically focused, can be set without an ex
 
 Sets the language in which results are returned.
 
-### `sources`
-> defaults to all sources
+### `layers`
+> defaults to all layers
 
-The Geocode Earth dataset is a combination of multiple data sources. This attribute can be used to limit results to a specific source (or multiple ones, comma separated). Please see our API documentation for a list of available sources: [geocode.earth/docs/reference/data_sources/](https://geocode.earth/docs/reference/data_sources/)
+The Geocode Earth dataset is a combination of multiple data layers. This attribute can be used to limit results to a specific layer (or multiple ones, comma separated). Please see our API documentation for a list of available layers: [geocode.earth/docs/reference/data_layers/](https://geocode.earth/docs/reference/data_layers/)
 
 ### `focus.point.lat` & `focus.point.lon`
 > defaults to unfocused


### PR DESCRIPTION
I noticed that the documentation mentions the `sources` param but not the `layers` param.

We'd like to continue supporting the `layers` param but recently started soft-deprecating the `sources` param, so we're removing mentions of `sources=` from all our documentation starting this month.

Rather than adding a new section for `layers` I've just rewritten the `sources` entry.
This commit covers both adding the new section and removing the old.