### PR TITLE
readme: default throttle value correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ All configuration happens through **attributes** on the element. `api_key` is th
 Your Geocode Earth API key. [Sign up for a free trial »](https://geocode.earth)
 
 ### `throttle`
-> defaults to `300`
+> defaults to `200`
 
 Used to prevent firing a request for every keystroke as the user types, in milliseconds.
 This is passed directly to the [`_.throttle`](https://lodash.com/docs/4.17.15#throttle) function.


### PR DESCRIPTION
it seems that the README is listing a different value from the [source code](https://github.com/geocodeearth/autocomplete-element/blob/main/src/autocomplete/autocomplete.js#L22)