### PR TITLE
fix: correctly instantiate new API client if options change

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "lodash.throttle": "^4.1.1",
         "lodash.unescape": "^4.0.1",
         "react": "^17.0.2",
-        "react-dom": "^17.0.2"
+        "react-dom": "^17.0.2",
+        "use-deep-compare-effect": "^1.8.1"
       },
       "devDependencies": {
         "esbuild": "^0.14.38",
@@ -46,6 +47,14 @@
     "node_modules/compute-scroll-into-view": {
       "version": "1.0.17",
       "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.2.tgz",
+      "integrity": "sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug==",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/downshift": {
       "version": "6.1.3",
@@ -563,6 +572,22 @@
       "engines": {
         "node": ">= 10.0.0"
       }
+    },
+    "node_modules/use-deep-compare-effect": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/use-deep-compare-effect/-/use-deep-compare-effect-1.8.1.tgz",
+      "integrity": "sha512-kbeNVZ9Zkc0RFGpfMN3MNfaKNvcLNyxOAAd9O4CBZ+kCBXXscn9s/4I+8ytUER4RDpEYs5+O6Rs4PqiZ+rHr5Q==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "dequal": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "react": ">=16.13"
+      }
     }
   },
   "dependencies": {
@@ -583,6 +608,11 @@
     },
     "compute-scroll-into-view": {
       "version": "1.0.17"
+    },
+    "dequal": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.2.tgz",
+      "integrity": "sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug=="
     },
     "downshift": {
       "version": "6.1.3",
@@ -878,6 +908,15 @@
     "universalify": {
       "version": "2.0.0",
       "dev": true
+    },
+    "use-deep-compare-effect": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/use-deep-compare-effect/-/use-deep-compare-effect-1.8.1.tgz",
+      "integrity": "sha512-kbeNVZ9Zkc0RFGpfMN3MNfaKNvcLNyxOAAd9O4CBZ+kCBXXscn9s/4I+8ytUER4RDpEYs5+O6Rs4PqiZ+rHr5Q==",
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "dequal": "^2.0.2"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "lodash.throttle": "^4.1.1",
     "lodash.unescape": "^4.0.1",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react-dom": "^17.0.2",
+    "use-deep-compare-effect": "^1.8.1"
   },
   "devDependencies": {
     "esbuild": "^0.14.38",


### PR DESCRIPTION
before this change a new client would not be instantiated when some
options change, as useMemo doesn’t deep compare the values in the
dependencies array. The workaround to use state for it didn’t actually
work.

Also useMemo is meant to only be used as a performance improvement,
which in this case is not enough because rely on the internal state of
the API client so we don’t want to recreate it unless its options
change.

Instead of useMemo we now use a deep compare effect which correctly compares the props, and then store the client as ref.