### PR TITLE
fix: dispatch error event when invalid API key is provided

### DIFF
--- a/src/autocomplete/autocomplete.js
+++ b/src/autocomplete/autocomplete.js
@@ -44,10 +44,14 @@ export default ({
   // deep compare is used to to only instantiate a new autocomplete API client if
   // required properties for it change
   useDeepCompareEffect(() => {
-    autocomplete.current = createAutocomplete(apiKey, params, {
-      ...options,
-      client: `ge-autocomplete${typeof VERSION !== 'undefined' ? `-${VERSION}` : ''}`
-    })
+    try {
+      autocomplete.current = createAutocomplete(apiKey, params, {
+        ...options,
+        client: `ge-autocomplete${typeof VERSION !== 'undefined' ? `-${VERSION}` : ''}`
+      })
+    } catch (err) {
+      onError(err)
+    }
   }, [apiKey, params, options])
 
   // search queries the autocomplete API

--- a/src/autocomplete/autocomplete.js
+++ b/src/autocomplete/autocomplete.js
@@ -116,6 +116,8 @@ export default ({
     setIsLoading(false) // hide loading indicator as this normally happens after a successful request
     if (typeof userOnError === 'function') {
       userOnError(error)
+    } else {
+      console.error(error)
     }
   }
 


### PR DESCRIPTION
Not catching this error means nothing gets rendered because it just crashes, which isn’t very nice.

Additionally if no error callback is provided errors are now logged instead of swallowed.