### PR TITLE
Fix bounding box parameter handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
-        "@geocodeearth/core-js": "^0.0.8",
+        "@geocodeearth/core-js": "^0.0.10",
         "downshift": "6.1.3",
         "lodash.escape": "^4.0.1",
         "lodash.template": "^4.5.0",
@@ -757,9 +757,10 @@
       }
     },
     "node_modules/@geocodeearth/core-js": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/@geocodeearth/core-js/-/core-js-0.0.8.tgz",
-      "integrity": "sha512-BGJJan1OYmTI6+ItWRXc1xHkJ/fLxjT9Jv8E7umo4obQN+Aszvskuozqr2I5c+nBwo0UE0AiacIbOPeDJpoVyA=="
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@geocodeearth/core-js/-/core-js-0.0.10.tgz",
+      "integrity": "sha512-PuNi2D22K30LPRpEv+Jv1QBJ3Tz6ZeqQ5iD9jTd3qFTEemoXCtMwxhc57jQ5T9EsP+usksIC/NKw6+QpRBHa8g==",
+      "license": "MIT"
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
@@ -4077,9 +4078,9 @@
       "requires": {}
     },
     "@geocodeearth/core-js": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/@geocodeearth/core-js/-/core-js-0.0.8.tgz",
-      "integrity": "sha512-BGJJan1OYmTI6+ItWRXc1xHkJ/fLxjT9Jv8E7umo4obQN+Aszvskuozqr2I5c+nBwo0UE0AiacIbOPeDJpoVyA=="
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@geocodeearth/core-js/-/core-js-0.0.10.tgz",
+      "integrity": "sha512-PuNi2D22K30LPRpEv+Jv1QBJ3Tz6ZeqQ5iD9jTd3qFTEemoXCtMwxhc57jQ5T9EsP+usksIC/NKw6+QpRBHa8g=="
     },
     "@jridgewell/sourcemap-codec": {
       "version": "1.5.5",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "module": "dist/index.js",
   "dependencies": {
-    "@geocodeearth/core-js": "^0.0.8",
+    "@geocodeearth/core-js": "^0.0.10",
     "downshift": "6.1.3",
     "lodash.escape": "^4.0.1",
     "lodash.template": "^4.5.0",

--- a/src/index.js
+++ b/src/index.js
@@ -111,10 +111,10 @@ class GEAutocomplete extends HTMLElement {
             radius: parseFloat(this.getAttribute('boundary.circle.radius'))
           }),
           rect: compact({
-            minLon: parseFloat(this.getAttribute('boundary.circle.rect.min_lon')),
-            maxLon: parseFloat(this.getAttribute('boundary.circle.rect.max_lon')),
-            minLat: parseFloat(this.getAttribute('boundary.circle.rect.min_lat')),
-            maxLat: parseFloat(this.getAttribute('boundary.circle.rect.max_lat'))
+            minLon: parseFloat(this.getAttribute('boundary.rect.min_lon')),
+            maxLon: parseFloat(this.getAttribute('boundary.rect.max_lon')),
+            minLat: parseFloat(this.getAttribute('boundary.rect.min_lat')),
+            maxLat: parseFloat(this.getAttribute('boundary.rect.max_lat'))
           })
         }),
         focusPoint: compact({

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -133,6 +133,19 @@ describe('GEAutocomplete props getter', () => {
     })
 
     describe('rect', () => {
+      it('maps all four rect attributes as floats', () => {
+        el.setAttribute('boundary.rect.min_lat', '40.477')
+        el.setAttribute('boundary.rect.max_lat', '40.917')
+        el.setAttribute('boundary.rect.min_lon', '-74.259')
+        el.setAttribute('boundary.rect.max_lon', '-73.700')
+        expect(el.props.params.boundary.rect).toEqual({
+          minLat: 40.477,
+          maxLat: 40.917,
+          minLon: -74.259,
+          maxLon: -73.700,
+        })
+      })
+
       it('omits rect when no rect attributes are set', () => {
         el.setAttribute('boundary.country', 'US')
         expect(el.props.params.boundary.rect).toBeUndefined()


### PR DESCRIPTION
Due to a combination of errors in this repo and geocodeearth/core-js, the `boundary.rect.*` parameters were not being passed properly.

This fixes the completely incorrect property names in this repo, requires a fixed versino of the `@geocodeearth/core-js` package, and adds some tests.